### PR TITLE
Refactor MCP Server to use FastAPI and implement OAuth service

### DIFF
--- a/mcp_oauth_service.py
+++ b/mcp_oauth_service.py
@@ -1,0 +1,327 @@
+import time
+import hashlib
+import base64
+
+class MCPBadRequest(Exception):
+    """Custom exception for OAuth bad requests."""
+    pass
+
+class SecureTokenStore:
+    """
+    Manages the storage of authorization codes and tokens.
+    """
+    def __init__(self):
+        self.auth_codes = {}  # Stores details related to auth codes
+        self.tokens = {}      # Stores access/refresh tokens
+
+    async def store_auth_code_details(self, auth_code: str, details: dict):
+        """
+        Stores details (e.g., client_id, code_challenge, server_id, redirect_uri)
+        associated with an authorization code.
+        """
+        self.auth_codes[auth_code] = details
+        print(f"SecureTokenStore: Stored auth code details for {auth_code}")
+
+    async def get_auth_code_details(self, auth_code: str) -> dict:
+        """
+        Retrieves details for an authorization code.
+        Returns None if not found.
+        """
+        details = self.auth_codes.get(auth_code)
+        if details:
+            print(f"SecureTokenStore: Retrieved auth code details for {auth_code}")
+        else:
+            print(f"SecureTokenStore: No details found for auth code {auth_code}")
+        return details
+
+    async def save_tokens(self, user_id: str, server_id: str, client_id: str, 
+                          access_token: str, refresh_token: str, expires_in: int):
+        """
+        Placeholder method to save access and refresh tokens.
+        """
+        token_key = f"{user_id}_{client_id}_{server_id}"
+        self.tokens[token_key] = {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "expires_in": expires_in,
+            "timestamp": time.time()
+        }
+        print(f"SecureTokenStore: Tokens saved for user {user_id}, client {client_id}, server {server_id}")
+
+    async def get_token_for_user(self, user_id: str, client_id: str, server_id: str):
+        """
+        Placeholder method to retrieve a token for a user.
+        Returns a dummy token or None.
+        """
+        token_key = f"{user_id}_{client_id}_{server_id}"
+        token_info = self.tokens.get(token_key)
+        if token_info:
+            print(f"SecureTokenStore: Retrieved token for user {user_id}, client {client_id}, server {server_id}")
+            return token_info["access_token"]
+        print(f"SecureTokenStore: No token found for user {user_id}, client {client_id}, server {server_id}")
+        return None
+
+class ClientRegistry:
+    """
+    Manages the registration and retrieval of client information.
+    """
+    def __init__(self):
+        self.clients = {}
+
+    async def register_client(self, client_id: str, client_info: dict):
+        """
+        Stores client information for a given client_id.
+        """
+        self.clients[client_id] = client_info
+        print(f"ClientRegistry: Registered client {client_id}")
+
+    async def get_client(self, client_id: str) -> dict:
+        """
+        Retrieves client information for a given client_id.
+        Returns None if not found.
+        """
+        client_info = self.clients.get(client_id)
+        if client_info:
+            print(f"ClientRegistry: Retrieved info for client {client_id}")
+        else:
+            print(f"ClientRegistry: No info found for client {client_id}")
+        return client_info
+
+class MCPOAuthService:
+    """
+    OAuth Service for MCP, handling authorization and token generation.
+    """
+    def __init__(self):
+        self.token_store = SecureTokenStore()
+        self.client_registry = ClientRegistry()
+        print("MCPOAuthService initialized with SecureTokenStore and ClientRegistry.")
+
+    async def generate_authorization_code(self, server_id: str, client_id: str, 
+                                          redirect_uri: str, code_challenge: str) -> str:
+        """
+        Generates an authorization code.
+        Placeholder implementation.
+        """
+        print("MCPOAuthService: generate_authorization_code (placeholder)")
+        auth_code = f"auth_code_for_{client_id}_{server_id}_{int(time.time())}"
+        # Store the code challenge along with other details
+        await self.token_store.store_auth_code_details(
+            auth_code,
+            {
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "code_challenge": code_challenge,
+                "server_id": server_id,
+                "timestamp": time.time()
+            }
+        )
+        return auth_code
+
+    async def validate_pkce(self, auth_code_details: dict, code_verifier: str) -> bool:
+        """
+        Validates the PKCE code challenge and verifier.
+        Placeholder implementation with simplified validation.
+        """
+        print("MCPOAuthService: validate_pkce (simplified placeholder)")
+        if not auth_code_details:
+            print("MCPOAuthService: validate_pkce - No auth_code_details provided.")
+            return False
+        
+        # In a real implementation, you would hash the code_verifier:
+        # hashed_verifier = hashlib.sha256(code_verifier.encode('utf-8')).digest()
+        # expected_challenge = base64.urlsafe_b64encode(hashed_verifier).rstrip(b'=').decode('utf-8')
+        # For this placeholder, we do a simplified check or just return True
+        # stored_challenge = auth_code_details.get('code_challenge')
+        # print(f"MCPOAuthService: validate_pkce - Stored challenge: {stored_challenge}, Verifier: {code_verifier}")
+        # For now, returning True as per subtask instructions for simplified validation.
+        print("MCPOAuthService: validate_pkce returning True (simplified validation)")
+        return True
+
+    async def generate_access_token(self, server_id: str, client_id: str, user_id: str = None) -> str:
+        """
+        Generates an access token.
+        Placeholder implementation.
+        """
+        print(f"MCPOAuthService: generate_access_token for client {client_id}, user {user_id or 'server'} (placeholder)")
+        return f"access_token_for_{client_id}_{user_id or 'server'}_{int(time.time())}"
+
+    async def generate_refresh_token(self, server_id: str, client_id: str, user_id: str = None) -> str:
+        """
+        Generates a refresh token.
+        Placeholder implementation.
+        """
+        print(f"MCPOAuthService: generate_refresh_token for client {client_id}, user {user_id or 'server'} (placeholder)")
+        return f"refresh_token_for_{client_id}_{user_id or 'server'}_{int(time.time())}"
+
+    async def handle_authorization_for_server(self, server_id: str, client_id: str, 
+                                             redirect_uri: str, code_challenge: str, state: str):
+        """
+        Handles the authorization request for a server.
+        """
+        print(f"MCPOAuthService: handle_authorization_for_server for server {server_id}, client {client_id}")
+        auth_code = await self.generate_authorization_code(
+            server_id=server_id,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge
+        )
+        return {"code": auth_code, "state": state}
+
+    async def exchange_code_for_token(self, server_id: str, code: str, 
+                                      code_verifier: str, client_id: str):
+        """
+        Exchanges an authorization code for an access token and refresh token.
+        """
+        print(f"MCPOAuthService: exchange_code_for_token for code {code}, client {client_id}")
+        auth_code_details = await self.token_store.get_auth_code_details(code)
+
+        if not auth_code_details:
+            raise MCPBadRequest("Invalid authorization code or code expired")
+
+        if auth_code_details.get('client_id') != client_id:
+            raise MCPBadRequest("Client ID mismatch")
+
+        # Validate PKCE
+        pkce_valid = await self.validate_pkce(auth_code_details, code_verifier)
+        if not pkce_valid:
+            raise MCPBadRequest("Invalid code verifier or code expired")
+
+        # Assuming successful validation, generate tokens
+        # User ID might be part of auth_code_details if user authentication happened
+        user_id = auth_code_details.get("user_id", "default_user") # Placeholder user_id
+
+        access_token = await self.generate_access_token(
+            server_id=server_id,
+            client_id=client_id,
+            user_id=user_id 
+        )
+        refresh_token = await self.generate_refresh_token(
+            server_id=server_id,
+            client_id=client_id,
+            user_id=user_id
+        )
+
+        expires_in = 3600
+        await self.token_store.save_tokens(
+            user_id=user_id,
+            server_id=server_id,
+            client_id=client_id,
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_in=expires_in
+        )
+        
+        # Conceptually, the auth code should be invalidated after use
+        # self.token_store.delete_auth_code(code) 
+        print(f"MCPOAuthService: Auth code {code} exchanged for tokens.")
+
+        return {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+            "refresh_token": refresh_token
+        }
+
+if __name__ == '__main__':
+    import asyncio
+
+    async def main():
+        # Test MCPBadRequest
+        try:
+            raise MCPBadRequest("This is a test error.")
+        except MCPBadRequest as e:
+            print(f"Caught expected error: {e}")
+
+        # Test ClientRegistry
+        client_registry = ClientRegistry()
+        await client_registry.register_client("client123", {"name": "Test Client App", "redirect_uris": ["http://localhost/callback"]})
+        client_info = await client_registry.get_client("client123")
+        print(f"Client info for client123: {client_info}")
+        non_existent_client = await client_registry.get_client("nonexistent")
+        print(f"Client info for nonexistent: {non_existent_client}")
+        print("-" * 20)
+
+        # Test SecureTokenStore
+        token_store = SecureTokenStore()
+        code_details_to_store = {"client_id": "client123", "code_challenge": "challenge_string", "server_id": "server789"}
+        await token_store.store_auth_code_details("authcodeABC", code_details_to_store)
+        retrieved_details = await token_store.get_auth_code_details("authcodeABC")
+        print(f"Retrieved auth code details: {retrieved_details}")
+        await token_store.save_tokens("user001", "server789", "client123", "new_access_token", "new_refresh_token", 3600)
+        user_token = await token_store.get_token_for_user("user001", "client123", "server789")
+        print(f"Token for user001: {user_token}")
+        print("-" * 20)
+
+        # Test MCPOAuthService
+        oauth_service = MCPOAuthService()
+        
+        # Simulate client registration (if MCPOAuthService were to handle it directly or via registry)
+        await oauth_service.client_registry.register_client(
+            "test_client_id", 
+            {"name": "My Test App", "redirect_uris": ["https://client.example.com/callback"]}
+        )
+
+        # 1. Authorization Request
+        print("\nSimulating Authorization Request:")
+        auth_response = await oauth_service.handle_authorization_for_server(
+            server_id="mcp_server_1",
+            client_id="test_client_id",
+            redirect_uri="https://client.example.com/callback",
+            code_challenge="example_code_challenge_string_S256", # In real flow, this is client-generated
+            state="csrf_state_token_123"
+        )
+        print(f"Authorization response: {auth_response}")
+        generated_auth_code = auth_response["code"]
+        print("-" * 20)
+
+        # 2. Token Exchange
+        print("\nSimulating Token Exchange:")
+        # Client would use the 'generated_auth_code' and its 'code_verifier'
+        # For this test, we assume the code_verifier matches the placeholder logic in validate_pkce
+        code_verifier_by_client = "example_code_verifier_corresponding_to_challenge" 
+        
+        try:
+            token_response = await oauth_service.exchange_code_for_token(
+                server_id="mcp_server_1",
+                code=generated_auth_code,
+                code_verifier=code_verifier_by_client,
+                client_id="test_client_id" 
+            )
+            print(f"Token exchange response: {token_response}")
+        except MCPBadRequest as e:
+            print(f"Token exchange failed: {e}")
+
+        print("-" * 20)
+        # Test exchange with a non-existent code
+        print("\nSimulating Token Exchange with invalid code:")
+        try:
+            token_response_invalid_code = await oauth_service.exchange_code_for_token(
+                server_id="mcp_server_1",
+                code="non_existent_code_123",
+                code_verifier="verifier",
+                client_id="test_client_id"
+            )
+            print(f"Token exchange response (invalid code): {token_response_invalid_code}")
+        except MCPBadRequest as e:
+            print(f"Token exchange failed as expected (invalid code): {e}")
+            
+        # Test exchange with client_id mismatch
+        print("\nSimulating Token Exchange with client_id mismatch:")
+        # First, generate a valid code
+        auth_res_for_mismatch = await oauth_service.handle_authorization_for_server(
+            server_id="mcp_server_1", client_id="actual_client", redirect_uri="uri", code_challenge="cc", state="s"
+        )
+        valid_code_for_mismatch = auth_res_for_mismatch["code"]
+        try:
+            await oauth_service.exchange_code_for_token(
+                server_id="mcp_server_1",
+                code=valid_code_for_mismatch,
+                code_verifier="cv",
+                client_id="mismatched_client" # This client_id is different from "actual_client"
+            )
+        except MCPBadRequest as e:
+            print(f"Token exchange failed as expected (client_id mismatch): {e}")
+
+
+    if __name__ == "__main__":
+        asyncio.run(main())

--- a/mcp_server_instance.py
+++ b/mcp_server_instance.py
@@ -1,0 +1,117 @@
+from fastapi import FastAPI, Form, Query, HTTPException # Removed Depends as it's not used
+# from flask import Flask, request, jsonify # Removed Flask imports
+from mcp_oauth_service import MCPOAuthService, MCPBadRequest 
+import asyncio
+import uvicorn # Added uvicorn
+
+class MCPServerInstance:
+    def __init__(self, server_id: str, oauth_service: MCPOAuthService):
+        self.server_id = server_id
+        self.oauth_service = oauth_service
+        self.app = FastAPI() # Changed from Flask to FastAPI
+        self._setup_routes()
+        print(f"MCPServerInstance '{server_id}' initialized with FastAPI.")
+
+    def _setup_routes(self):
+        @self.app.get("/authorize")
+        async def authorize(
+            client_id: str = Query(...), 
+            redirect_uri: str = Query(...), 
+            code_challenge: str = Query(...), 
+            state: str = Query(...),
+            # response_type: str = Query(...) # Optional: if strict validation needed
+        ):
+            print(f"MCPServerInstance[{self.server_id}]: Received GET /authorize request.")
+            # FastAPI handles missing required parameters automatically with Query(...)
+            # if response_type != 'code': # Example of additional validation if needed
+            #     raise HTTPException(status_code=400, detail={"error": "invalid_response_type", "description": "Only 'code' response_type is supported."})
+            try:
+                print(f"MCPServerInstance[{self.server_id}]: /authorize - Calling oauth_service.handle_authorization_for_server...")
+                result = await self.oauth_service.handle_authorization_for_server(
+                    server_id=self.server_id,
+                    client_id=client_id,
+                    redirect_uri=redirect_uri,
+                    code_challenge=code_challenge,
+                    state=state
+                )
+                print(f"MCPServerInstance[{self.server_id}]: /authorize - Success. Result: {result}")
+                return result
+            except MCPBadRequest as e:
+                print(f"MCPServerInstance[{self.server_id}]: /authorize - MCPBadRequest: {e}")
+                raise HTTPException(status_code=400, detail=str(e))
+            except Exception as e:
+                print(f"MCPServerInstance[{self.server_id}]: /authorize - Unexpected error: {e}")
+                # In a real app, log the exception e more thoroughly
+                raise HTTPException(status_code=500, detail="An unexpected error occurred.")
+
+        @self.app.post("/token")
+        async def token(
+            grant_type: str = Form(...),
+            code: str = Form(...),
+            code_verifier: str = Form(...),
+            client_id: str = Form(...)
+            # redirect_uri: str = Form(None) # Optional: if your service requires it
+        ):
+            print(f"MCPServerInstance[{self.server_id}]: Received POST /token request.")
+            if grant_type != 'authorization_code':
+                print(f"MCPServerInstance[{self.server_id}]: /token - Unsupported grant_type: {grant_type}")
+                raise HTTPException(status_code=400, detail={"error": "unsupported_grant_type", 
+                                                              "description": "Only 'authorization_code' grant_type is supported."})
+            
+            # FastAPI handles missing required parameters automatically with Form(...)
+            try:
+                print(f"MCPServerInstance[{self.server_id}]: /token - Calling oauth_service.exchange_code_for_token...")
+                result = await self.oauth_service.exchange_code_for_token(
+                    server_id=self.server_id,
+                    code=code,
+                    code_verifier=code_verifier,
+                    client_id=client_id
+                    # redirect_uri=redirect_uri # Pass if your service logic needs it
+                )
+                print(f"MCPServerInstance[{self.server_id}]: /token - Success. Result: {result}")
+                return result
+            except MCPBadRequest as e:
+                print(f"MCPServerInstance[{self.server_id}]: /token - MCPBadRequest: {e}")
+                # According to OAuth 2.0, error for token endpoint can be 'invalid_grant' or 'invalid_client'
+                raise HTTPException(status_code=400, detail=str(e))
+            except Exception as e:
+                print(f"MCPServerInstance[{self.server_id}]: /token - Unexpected error: {e}")
+                # In a real app, log the exception e more thoroughly
+                raise HTTPException(status_code=500, detail="An unexpected error occurred.")
+                
+    # def run(self, host='0.0.0.0', port=8080): # Removed run method
+    #     print(f"MCPServerInstance[{self.server_id}]: Starting Flask app on {host}:{port}...")
+    #     self.app.run(host=host, port=port, debug=True) 
+
+# __main__ block for testing
+if __name__ == '__main__':
+    host = '0.0.0.0' # Or '127.0.0.1'
+    port = 8080
+
+    oauth_service_instance = MCPOAuthService()
+    
+    async def setup_dummy_client_for_testing():
+        test_client_id = "test_mcp_client_001" 
+        await oauth_service_instance.client_registry.register_client(
+            test_client_id, 
+            {"name": "Test MCP Client Application", 
+             "redirect_uris": [f"http://{host}:{port}/callback", f"http://localhost:{port}/callback"]}
+        )
+        print(f"Dummy client '{test_client_id}' registered in MCPOAuthService for testing.")
+
+    asyncio.run(setup_dummy_client_for_testing())
+
+    server_instance = MCPServerInstance(
+        server_id="mcp_instance_alpha_001_fastapi", 
+        oauth_service=oauth_service_instance
+    )
+    
+    # The FastAPI application instance to run with uvicorn
+    # This makes it explicit for uvicorn.run
+    app_to_run = server_instance.app 
+
+    print(f"Attempting to start MCPServerInstance (FastAPI) 'mcp_instance_alpha_001_fastapi' on http://{host}:{port}...")
+    # Use uvicorn to run the FastAPI app
+    uvicorn.run(app_to_run, host=host, port=port) # Removed reload=True, can be added for dev
+    
+    print("MCPServerInstance (FastAPI) has finished (this message may not be reached if server runs indefinitely).")


### PR DESCRIPTION
This commit introduces an MCP (Master Control Program) gateway structure with a focus on OAuth 2.1 compliance for large-scale deployments.

Key changes include:

1.  **`MCPOAuthService` (`mcp_oauth_service.py`):**
    *   A centralized service designed to handle core OAuth logic.
    *   Includes placeholder methods for authorization code generation, PKCE validation, and token generation.
    *   Basic in-memory `SecureTokenStore` and `ClientRegistry` for managing auth codes, tokens, and client registrations.
    *   Defines `MCPBadRequest` for specific OAuth errors.

2.  **`MCPServerInstance` (`mcp_server_instance.py`):**
    *   Initially generated using Flask, then refactored to FastAPI.
    *   Exposes MCP-compliant `/authorize` and `/token` endpoints.
    *   Delegates OAuth logic to an instance of `MCPOAuthService`.
    *   Uses FastAPI's features for request handling, parameter validation (`Query`, `Form`), and error responses (`HTTPException`).
    *   Includes a `__main__` block for running with Uvicorn.

The architecture is based on the provided "MCP Server OAuth Architecture Guide," specifically addressing "Scenario 3: Large-Scale Deployment" by creating a centralized OAuth service that individual MCP server instances can utilize.

This provides a foundational implementation that can be extended with persistent storage, robust security measures, and other production-grade features as outlined in the guidance provided.